### PR TITLE
System for Destroying Branches

### DIFF
--- a/Assets/Scenes/PowerOn-Prototype.unity
+++ b/Assets/Scenes/PowerOn-Prototype.unity
@@ -319,6 +319,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1538617092}
+  - {fileID: 1642708139}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -908,6 +909,81 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1642708138
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1642708139}
+  - component: {fileID: 1642708141}
+  - component: {fileID: 1642708140}
+  m_Layer: 5
+  m_Name: Selected Action
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1642708139
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1642708138}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 312891258}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -398.5, y: -67.1}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1642708140
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1642708138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 25
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: <=> Grow Branch <=>
+--- !u!222 &1642708141
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1642708138}
+  m_CullTransparentMesh: 0
 --- !u!1001 &1667908994
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BranchScript.cs
+++ b/Assets/Scripts/BranchScript.cs
@@ -7,6 +7,8 @@ public class BranchScript : MonoBehaviour
     private Transform _transform;
     private ForestController _controller;
     private BoxCollider2D _collider;
+    private bool _isFading;
+    private float _storedSap;
 
     public float speed;
     public float xScale;
@@ -24,6 +26,11 @@ public class BranchScript : MonoBehaviour
 
     #endregion Public Properties
 
+    public void FadeAndDestroy()
+    {
+        _isFading = true;
+    }
+
     private void Start() 
     {
         _controller = GameObject.Find("Forest Controller").GetComponent<ForestController>();
@@ -39,11 +46,14 @@ public class BranchScript : MonoBehaviour
         }
 
         this.IsGrowing = true;
+        _isFading = false;
+        _storedSap = 0;
 	}
 	
 	private void Update() 
     {
         Grow();
+        HandleFading();
 	}
 
     #region Private Helper Functions
@@ -53,12 +63,35 @@ public class BranchScript : MonoBehaviour
         if (_transform.localScale.x < maxScale.x && _controller.HasSap && this.IsGrowing)
         {
             _transform.localScale += new Vector3(speed, 0f, 0f);
-            _controller.Sap -= 1;
+            _controller.Sap--;
+            _storedSap++;
         }
 
         if (Input.GetMouseButtonUp(0))
         {
             this.IsGrowing = false;
+        }
+    }
+
+    private void HandleFading()
+    {
+        if (_isFading)
+        {
+            var sprite = GetComponent<SpriteRenderer>();
+            
+            var newColor = sprite.color;
+
+            var alpha = sprite.color.a;
+            alpha -= 0.03f;
+
+            newColor.a = alpha;
+            sprite.color = newColor;
+
+            if (alpha <= 0f)
+            {
+                _controller.Sap += _storedSap;
+                Destroy(gameObject);
+            }
         }
     }
 

--- a/Assets/Scripts/BranchScript.cs
+++ b/Assets/Scripts/BranchScript.cs
@@ -45,7 +45,7 @@ public class BranchScript : MonoBehaviour
             _collider.offset = new Vector2(-_collider.offset.x, _collider.offset.y);
         }
 
-        this.IsGrowing = true;
+        IsGrowing = true;
         _isFading = false;
         _storedSap = 0;
 	}
@@ -60,7 +60,7 @@ public class BranchScript : MonoBehaviour
 
     private void Grow()
     {
-        if (_transform.localScale.x < maxScale.x && _controller.HasSap && this.IsGrowing)
+        if (_transform.localScale.x < maxScale.x && _controller.HasSap && IsGrowing)
         {
             _transform.localScale += new Vector3(speed, 0f, 0f);
             _controller.Sap--;
@@ -69,7 +69,7 @@ public class BranchScript : MonoBehaviour
 
         if (Input.GetMouseButtonUp(0))
         {
-            this.IsGrowing = false;
+            IsGrowing = false;
         }
     }
 

--- a/Assets/Scripts/ExtensionMethods.cs
+++ b/Assets/Scripts/ExtensionMethods.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+public static class Extensions
+{
+
+    public static T Next<T>(this T inputEnum) where T : struct
+    {
+        if (!typeof(T).IsEnum) throw new ArgumentException(String.Format("Argument {0} is not an Enum", typeof(T).FullName));
+
+        T[] values = (T[])Enum.GetValues(inputEnum.GetType());
+        int index = Array.IndexOf<T>(values, inputEnum) + 1;
+        return (values.Length == index) ? values[0] : values[index];
+    }
+
+    public static T Previous<T>(this T inputEnum) where T : struct
+    {
+        if (!typeof(T).IsEnum) throw new ArgumentException(String.Format("Argument {0} is not an Enum", typeof(T).FullName));
+
+        T[] values = (T[])Enum.GetValues(inputEnum.GetType());
+        int index = Array.IndexOf<T>(values, inputEnum) - 1;
+        return (index < 0) ? values[values.Length-1] : values[index];
+    }
+}

--- a/Assets/Scripts/ExtensionMethods.cs.meta
+++ b/Assets/Scripts/ExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8f867c7137e4b342b6169379e9aaa5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ForestController.cs
+++ b/Assets/Scripts/ForestController.cs
@@ -83,6 +83,7 @@ public class ForestController : MonoBehaviour
     {
         HandleLeftClicks();
         HandleScrolling();
+        HandleArrowKeyPresses();
     }
 
     #region Private Helper Functions
@@ -129,6 +130,18 @@ public class ForestController : MonoBehaviour
         if (ScrollingDown)
         {
             SelectedAction = SelectedAction.Previous(); ;
+        }
+    }
+
+    private void HandleArrowKeyPresses()
+    {
+        if (Input.GetKeyDown(KeyCode.UpArrow))
+        {
+            SelectedAction = SelectedAction.Next();
+        }
+        if (Input.GetKeyDown(KeyCode.DownArrow))
+        {
+            SelectedAction = SelectedAction.Previous();
         }
     }
 

--- a/Assets/Scripts/ForestController.cs
+++ b/Assets/Scripts/ForestController.cs
@@ -89,11 +89,11 @@ public class ForestController : MonoBehaviour
 
     private void HandleLeftClicks() 
     {
-        if (Input.GetMouseButtonDown(0) && HasSap) 
+        if (Input.GetMouseButtonDown(0)) 
         {
             var mouseRayTarget = Physics2D.Raycast(mainCam.ScreenToWorldPoint(Input.mousePosition), Vector2.zero);
 
-            if (SelectedAction == Action.Grow)
+            if (SelectedAction == Action.Grow && HasSap)
             {
                 if (mouseRayTarget.collider != null)
                 {


### PR DESCRIPTION
Goal: Create a system for switching actions and destroying branches

What I changed:
- Important files:
   - ForestController.cs
   - BranchScript.cs
   - ExtensionMethods.cs
- Added an enum called Actions to keep track of the different actions that the forest player has. Currently it can only Grow and Destroy branches
- Added a UI text element to display which action is currently selected by the forest player
- Added listeners on the mouse scroll wheel which switch the Action that is equipped
- When the Action switches in ForestController.cs, the UI text gets updated (via the setter called SelectedAction)
- When the Destroy Branch action is selected, you can destroy branches that are above the squirrel
   - You cannot destroy branches that are below the squirrel
- Added a variable in BranchScript.cs to track how much sap it cost to grow that branch
- When a branch is destroyed, the sap that it cost to grow it is refunded (after a short fading animation)

How To Test:
- Try switching Actions as the tree player by scrolling with the mouse wheel. It feels intuitive on my mouse but it could be not so good on a mouse with a less tactile wheel
   - If you can think of a better way to switch actions, please leave suggestions
- Ensure that you can only destroy branches in Destroy Branch mode
- Ensure that branches actually get destroyed after they fade out. If you hit your head where it used to be, then it was not actually destroyed
- Make sure that the sap cost of the branch is refunded after destroying it. 

Notes:
- I don't feel like this code is particularly clean. Please feel free to leave refactor suggestions if you have any. (Not promising I'll have time to implement them before the deadline)
